### PR TITLE
Run as root within container to allow writing to root owned host volumes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM nipy/mindboggle
 MAINTAINER Mindboggle <anishakeshavan@gmail.com>
+USER root
 RUN mkdir ~/code
 COPY run.py ~/code/run.py
 COPY version ~/code/version


### PR DESCRIPTION
This fixes OpenNeuroOrg/openneuro#79. Without this change, the user is inherited from nipy/mindboggle and depends on the version of that image used as a parent since it's defined in an [environment variable](https://github.com/nipy/mindboggle/blob/master/install/Dockerfile.mindboggle.complete#L100). This means the output directory is unwritable since the volume's backing filesystem is owned by root.